### PR TITLE
Set a unique correlator qury param for each banner ad request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,61 @@
+## Description 🤔
+
+<!-- 
+    Please include a summary of the change along with any relevant context.
+    List any dependencies that are required for this change.
+-->
+
+## Reason for change 🤖
+
+<!--
+    Please provide a link to the Jira ticket. 
+    Add any additional details and/or motivation if appropriate.
+-->
+
+## Type of change 🧩
+
+<!-- Please delete options that are not relevant. --> 
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Other (please explain in the description section above)
+
+## How have you tested this works? 🧪
+
+### Devices / Simulators
+
+I have tested on the following devices and/or simulators.
+
+<!-- Please delete options that are not relevant. --> 
+
+ - [ ] iPhone 12 
+ - [ ] iPhone 11 
+ - [ ] iPhone X
+ - [ ] iPhone SE (2nd Generation)
+ - [ ] iPhone SE (1st Generation)
+ - [ ] iPad (portrait)
+ - [ ] iPad (landscape)
+ - [ ] Android (Samsung)
+ - [ ] Android (Pixel)
+
+I have tested on the following platforms.
+
+<!-- Please delete options that are not relevant. --> 
+
+ - [ ] iOS 14
+ - [ ] iOS 13
+ - [ ] iOS 12
+ - [ ] Android 11
+ - [ ] Android 10
+ - [ ] Android 9
+
+## Checklist ✔
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have provided details on how I have tested my code
+- [ ] I have referenced the ticket number above
+- [ ] I have provided a description of the ticket
+

--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -241,7 +241,7 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
         }
 
         if (correlator == null) {
-            correlator = (String) Targeting.getCorelator(adUnitID);
+            correlator = (String) Targeting.genRandomCorrelator();
         }
         Bundle bundle = new Bundle();
         bundle.putString("correlator", correlator);

--- a/android/src/main/java/com/matejdr/admanager/utils/Targeting.java
+++ b/android/src/main/java/com/matejdr/admanager/utils/Targeting.java
@@ -161,7 +161,7 @@ public class Targeting {
         return correlators.get(adUnitID);
     }
 
-    private static String genRandomCorrelator() {
+    public static String genRandomCorrelator() {
         StringBuilder stringBuilder = new StringBuilder();
         Random random = new Random();
         for (int i = 0; i < 16; i++) {

--- a/ios/RNAdManagerBannerView.m
+++ b/ios/RNAdManagerBannerView.m
@@ -95,7 +95,7 @@
 
     GADExtras *extras = [[GADExtras alloc] init];
     if (_correlator == nil) {
-        _correlator = getCorrelator(_adUnitID);
+        _correlator = generateCorrelator();
     }
     extras.additionalParameters = [[NSDictionary alloc] initWithObjectsAndKeys:
                                    _correlator, @"correlator",

--- a/ios/RNAdManagerUtils.h
+++ b/ios/RNAdManagerUtils.h
@@ -3,3 +3,4 @@
 NSArray *__nullable RNAdManagerProcessTestDevices(NSArray *__nullable testDevices, id _Nonnull simulatorId);
 NSString *__nullable getRandomPINString(NSInteger length);
 NSString *__nullable getCorrelator(NSString *__nullable adUnitID);
+NSString* generateCorrelator();

--- a/ios/RNAdManagerUtils.m
+++ b/ios/RNAdManagerUtils.m
@@ -49,3 +49,12 @@ NSString *__nullable getCorrelator(NSString *adUnitID)
 
     return correlator;
 }
+
+
+NSString* generateCorrelator()
+{
+
+    NSString *correlator = getRandomPINString(16);
+
+    return correlator;
+}


### PR DESCRIPTION
## Description 🤔

The correlator in Google Ad Manager is the value that tells Ad Manager if you are still on the same screen, so ads should be unique, or if you have moved to a different screen, so ads should be different. By default, after 30 seconds the correlator value expires.

We have found that the correlator value is not changing between screens, so the google ad server assumes you are on the same page/screen constantly and requires unique ads. This means that you can 'run out' of ads when you navigate through the app. For MVP, the first edit to the request correlator we want the request correlator to have a random value for each ad request. 

## Reason for change 🤖
[https://economist.atlassian.net/browse/CCA-496?atlOrigin=eyJpIjoiYTFlYjQxNmI5ZGYyNDE1ZDk0NzQ0NDE2ZTU3Y2U4NTQiLCJwIjoiaiJ9](https://economist.atlassian.net/browse/CCA-496?atlOrigin=eyJpIjoiYTFlYjQxNmI5ZGYyNDE1ZDk0NzQ0NDE2ZTU3Y2U4NTQiLCJwIjoiaiJ9)

[https://economist.atlassian.net/browse/MAPP-1204](https://economist.atlassian.net/browse/MAPP-1204)
## Type of change 🧩

<!-- Please delete options that are not relevant. --> 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## How have you tested this works? 🧪

### Devices / Simulators

I have tested on the following devices and/or simulators.

<!-- Please delete options that are not relevant. --> 

 - [ ] iPhone 12 
 - [x] iPhone 11 
 - [ ] iPhone X
 - [ ] iPhone SE (2nd Generation)
 - [ ] iPhone SE (1st Generation)
 - [ ] iPad (portrait)
 - [ ] iPad (landscape)
 - [ ] Android (Samsung)
 - [ ] Android (Pixel)

I have tested on the following platforms.

<!-- Please delete options that are not relevant. --> 

 - [x] iOS 14
 - [ ] iOS 13
 - [ ] iOS 12
 - [ ] Android 11
 - [x] Android 10
 - [ ] Android 9

## Checklist ✔

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
