### PR TITLE
Block descendant focus requests

### DIFF
--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -3,6 +3,7 @@ package com.matejdr.admanager;
 import android.app.Activity;
 import android.location.Location;
 import android.os.Bundle;
+import android.view.ViewGroup;
 
 import androidx.annotation.Nullable;
 
@@ -83,6 +84,7 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
         this.adView = new AdManagerAdView(currentActivityContext);
         this.adView.setLayoutParams(layoutParams);
         this.adView.setAppEventListener(this);
+        this.adView.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
         this.adView.setAdListener(new AdListener() {
             @Override
             public void onAdLoaded() {


### PR DESCRIPTION
Fixing the following crash related to the Android layouting. This problem happen because sometimes the Ad displayed is a WebView under the hood, and WebView itself will trigger a focus request.

<img width="1125" alt="Screenshot 2022-03-29 at 09 27 50" src="https://user-images.githubusercontent.com/6296883/160580589-70b207f3-afad-4b85-a915-e547124c3855.png">
